### PR TITLE
[WIP] Use relative paths for blob titles

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -238,6 +238,10 @@ func (o *BuildOptions) Run(ctx context.Context) error {
 			return err
 		}
 
+		if err := client.MapPaths(renderSpace.Path(), descs...); err != nil {
+			return err
+		}
+
 		if err := client.Execute(ctx); err != nil {
 			return fmt.Errorf("error publishing content to %s: %v", o.Destination, err)
 		}

--- a/cli/build.go
+++ b/cli/build.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -218,6 +219,14 @@ func (o *BuildOptions) Run(ctx context.Context) error {
 		descs, err := client.GatherDescriptors(files...)
 		if err != nil {
 			return err
+		}
+
+		// Absolute paths cause unexpected behavior when pulling.
+		// only use the relative path for the title (filename).
+		for _, desc := range descs {
+			title := desc.Annotations["org.opencontainers.image.title"]
+			relPath := strings.TrimPrefix(title, renderSpace.Path()+"/")
+			desc.Annotations["org.opencontainers.image.title"] = relPath
 		}
 
 		configDesc, err := client.GenerateConfig(nil)

--- a/registryclient/client.go
+++ b/registryclient/client.go
@@ -18,4 +18,5 @@ type Client interface {
 	GenerateManifest(ocispec.Descriptor, map[string]string, ...ocispec.Descriptor) error
 	// Execute performs the copy of OCI artifacts.
 	Execute(context.Context) error
+	MapPaths(string, ...ocispec.Descriptor) error
 }

--- a/registryclient/orasclient/oras.go
+++ b/registryclient/orasclient/oras.go
@@ -70,6 +70,15 @@ func (c *orasClient) Execute(ctx context.Context) error {
 	return nil
 }
 
+// Execute performs the copy of OCI artifacts.
+func (c *orasClient) MapPaths(workDir string, descriptors ...ocispec.Descriptor) error {
+	for _, desc := range descriptors {
+		fpath := workDir + "/" + desc.Annotations["org.opencontainers.image.title"]
+		c.fileStore.MapPath(desc.Annotations["org.opencontainers.image.title"], fpath)
+	}
+	return nil
+}
+
 func loadFiles(store *content.File, files ...string) ([]ocispec.Descriptor, error) {
 	var descs []ocispec.Descriptor
 	for _, fileRef := range files {


### PR DESCRIPTION
Fixes #10 

Does not include the workspace directory in the relative path of each file. This allows for the directory structure of the original content to be output to a directory that the user specifies when pulling. 