### PR TITLE
fix(parser): add support for "-" in filenames during parsing

### DIFF
--- a/builder/parser/json_test.go
+++ b/builder/parser/json_test.go
@@ -51,6 +51,16 @@ func TestGetLinkableData_JSON(t *testing.T) {
 			expLinks:    map[string]interface{}{"info_json_uor": "info.json.uor"},
 		},
 		{
+			name:  "Success/SupportedSpecialCharacter",
+			input: "testdata/valid.json",
+			tFuncs: []TemplatingFunc{
+				func(i interface{}) bool { return true },
+			},
+			p:           &jsonParser{filename: "valid.json"},
+			expLinksLen: 1,
+			expLinks:    map[string]interface{}{"valid_name": "valid-name"},
+		},
+		{
 			name:  "Failure/InvalidCharacterForTemplate",
 			input: "testdata/invalid.json",
 			tFuncs: []TemplatingFunc{

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -51,8 +51,11 @@ func ByContentType(filename string, data []byte) (Parser, error) {
 // ConvertFilenameForGoTemplateValue converts the current
 // file string to a value that is an acceptable variable for Go templating.
 func ConvertFilenameForGoTemplateValue(filename string) string {
-	// TODO: gather a list of invalid character.
-	filename = strings.Replace(filename, ".", "_", -1)
-	filename = strings.Replace(filename, string(filepath.Separator), "_", -1)
+	goTemplateSpecialCharacters := []string{".", string(filepath.Separator), "-"}
+	replaceCh := "_"
+
+	for _, ch := range goTemplateSpecialCharacters {
+		filename = strings.Replace(filename, ch, replaceCh, -1)
+	}
 	return filename
 }

--- a/builder/parser/parser_test.go
+++ b/builder/parser/parser_test.go
@@ -21,9 +21,19 @@ func TestConvertFilenameForGoTemplateValue(t *testing.T) {
 			exp:   "fish_jpg",
 		},
 		{
-			name:  "Valid/RelativePathNewDirecotry",
+			name:  "Valid/RelativePathNewDirectory",
 			input: "images/fish.jpg",
 			exp:   "images_fish_jpg",
+		},
+		{
+			name:  "Valid/SpecialCharacter",
+			input: "images/fish-1.jpg",
+			exp:   "images_fish_1_jpg",
+		},
+		{
+			name:  "Valid/SpecialCharacterAccepted",
+			input: "images/fish-1.jpg",
+			exp:   "images_fish_1_jpg",
 		},
 		{
 			name:  "Valid/RelativePathPreviousDirectory",

--- a/builder/parser/testdata/valid.json
+++ b/builder/parser/testdata/valid.json
@@ -1,0 +1,3 @@
+{
+    "images": "valid-name"
+}


### PR DESCRIPTION
Adds support for "-" character in filenames.

Fixes #8

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>