### PR TITLE
build multi-arch binaries and multi-arch container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,34 @@
+FROM registry.access.redhat.com/ubi9/ubi as builder
+
+ARG DNF_FLAGS="\
+  -y \
+  --nodocs \
+  --releasever 9 \
+  --setopt install_weak_deps=false \
+  --installroot \
+"
+ARG DNF_PACKAGES="\
+  openssl \
+  coreutils-single \
+  glibc-minimal-langpack \
+"
+
+ARG ROOTFS="/rootfs"
+RUN set -ex \
+     && mkdir -p ${ROOTFS} \
+     && dnf install ${DNF_FLAGS} ${ROOTFS} ${DNF_PACKAGES} \
+     && dnf clean all ${DNF_FLAGS} ${ROOTFS} \
+     && rm -rf ${ROOTFS}/var/cache/* \
+    && echo
+
+FROM scratch
+COPY --from=builder /rootfs/ /
+
+ARG TARGETARCH
+COPY ./bin/client-linux-${TARGETARCH} /usr/local/bin/client
+RUN set -ex \
+     && /usr/local/bin/client version \
+    && echo
+
+ENTRYPOINT ["/usr/local/bin/client"]
+CMD ["version"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GO := go
 GO_BUILD_PACKAGES := ./cmd/...
 GO_BUILD_BINDIR :=./bin
 GIT_COMMIT := $(or $(SOURCE_GIT_COMMIT),$(shell git rev-parse --short HEAD))
+GIT_TAG :="$(shell git tag | sort -V | tail -1)"
 
 GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/client/cli.version="$(shell git tag | sort -V | tail -1)" \
 				   -X github.com/uor-framework/client/cli.buildData="dev" \
@@ -11,8 +12,32 @@ GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/client/cli.version="$(shell git t
 
 build:
 	mkdir -p ${GO_BUILD_BINDIR}
-	$(GO) build -o $(GO_BUILD_BINDIR)/client -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	$(GO) build -o $(GO_BUILD_BINDIR)/$(ARCH)-client -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 .PHONY: build
+
+build-all-arch:
+	@rm -rf ./$(GO_BUILD_BINDIR)/*
+	env GOOS=linux   GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-amd64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=linux   GOARCH=arm64   $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-arm64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=linux   GOARCH=s390x	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-s390x   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=linux   GOARCH=ppc64le $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-ppc64le -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=linux   GOARCH=riscv64 $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-riscv64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=darwin  GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-amd64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=darwin  GOARCH=arm64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-arm64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	env GOOS=windows GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-windows-amd64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: multi-arch
+
+container:
+	buildah manifest create ghcr.io/uor-framework/client:$(GIT_TAG)
+	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=arm64   --arch arm64   --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-arm64:$(GIT_TAG)   --file ./Containerfile
+	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=amd64   --arch amd64   --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-amd64:$(GIT_TAG)   --file ./Containerfile
+	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=s390x   --arch s390x   --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-s390x:$(GIT_TAG)   --file ./Containerfile
+	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=ppc64le --arch ppc64le --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-ppc64le:$(GIT_TAG) --file ./Containerfile
+.PHONY: container
+
+container-push:
+	buildah manifest push --all ghcr.io/uor-framework/client docker://ghcr.io/uor-framework/client:$(GIT_TAG)
+.PHONY: container-push
 
 vendor:
 	$(GO) mod tidy
@@ -40,5 +65,5 @@ vet:
 	$(GO) vet ./...
 .PHONY: vet
 
-all: clean vendor test-unit build
+all: clean vendor test-unit build-all-arch container
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,6 @@ GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/client/cli.version="$(shell git t
 
 build:
 	mkdir -p ${GO_BUILD_BINDIR}
-	$(GO) build -o $(GO_BUILD_BINDIR)/$(ARCH)-client -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-.PHONY: build
-
-build-all-arch:
-	@rm -rf ./$(GO_BUILD_BINDIR)/*
 	env GOOS=linux   GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-amd64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 	env GOOS=linux   GOARCH=arm64   $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-arm64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 	env GOOS=linux   GOARCH=s390x	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-s390x   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
@@ -25,19 +20,7 @@ build-all-arch:
 	env GOOS=darwin  GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-amd64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 	env GOOS=darwin  GOARCH=arm64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-arm64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 	env GOOS=windows GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-windows-amd64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-.PHONY: multi-arch
-
-container:
-	buildah manifest create ghcr.io/uor-framework/client:$(GIT_TAG)
-	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=arm64   --arch arm64   --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-arm64:$(GIT_TAG)   --file ./Containerfile
-	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=amd64   --arch amd64   --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-amd64:$(GIT_TAG)   --file ./Containerfile
-	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=s390x   --arch s390x   --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-s390x:$(GIT_TAG)   --file ./Containerfile
-	buildah build --manifest ghcr.io/uor-framework/client --build-arg TARGETARCH=ppc64le --arch ppc64le --volume ${PWD}/bin:/data:z --tag ghcr.io/uor-framework/client-ppc64le:$(GIT_TAG) --file ./Containerfile
-.PHONY: container
-
-container-push:
-	buildah manifest push --all ghcr.io/uor-framework/client docker://ghcr.io/uor-framework/client:$(GIT_TAG)
-.PHONY: container-push
+.PHONY: build
 
 vendor:
 	$(GO) mod tidy
@@ -65,5 +48,5 @@ vet:
 	$(GO) vet ./...
 .PHONY: vet
 
-all: clean vendor test-unit build-all-arch container
+all: clean vendor test-unit build
 .PHONY: all


### PR DESCRIPTION
## Does:
Build multi-arch binaries and containers.

## Does not:
Does not automate the publishing of all binaries or pushing container.

## How To:
```sh
make build-all-arch
make container
make container-push
```
or
```sh
make all
make container-push
```

Result:
```sh
# ls -lah ./bin
45M client-darwin-amd64
44M client-darwin-arm64
58M client-linux-amd64
44M client-linux-arm64
44M client-linux-ppc64le
44M client-linux-riscv64
47M client-linux-s390x
45M client-windows-amd64

# buildah images
REPOSITORY                             TAG      IMAGE ID       CREATED          SIZE
ghcr.io/uor-framework/client-ppc64le   v0.2.0   df172325cdb4   25 minutes ago   93.1 MB
ghcr.io/uor-framework/client-s390x     v0.2.0   2139b9e75493   27 minutes ago   87.4 MB
ghcr.io/uor-framework/client-amd64     v0.2.0   98bf336eeef3   28 minutes ago   101 MB
ghcr.io/uor-framework/client-arm64     v0.2.0   44f36559c04e   29 minutes ago   87.1 MB
ghcr.io/uor-framework/client           v0.2.0   b232ac903061   30 minutes ago   110 B

# podman run --rm -it --pull never 44f36559c04e
UOR Client:
 Version:       v0.2.0+dev
 Go Version:    go1.18.3
 Git Commit:    3ba03d3
 Build Date:    2022-07-09T23:50:21Z
 Platform:      linux/arm64
```

### Other:
closes #38 