### PR TITLE
build(Makefile): sets linux amd64 as the default build and creates cr…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/client/cli.version="$(shell git t
 				   -X github.com/uor-framework/client/cli.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
 build: prep-build-dir
-	env GOOS=linux  GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+	$(GO) build -o $(GO_BUILD_BINDIR)/client  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 .PHONY: build
 
 cross-build-darwin-amd64:

--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,48 @@ GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/client/cli.version="$(shell git t
 				   -X github.com/uor-framework/client/cli.commit="$(GIT_COMMIT)" \
 				   -X github.com/uor-framework/client/cli.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
-build:
-	mkdir -p ${GO_BUILD_BINDIR}
-	env GOOS=linux   GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-amd64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=linux   GOARCH=arm64   $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-arm64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=linux   GOARCH=s390x	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-s390x   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=linux   GOARCH=ppc64le $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-ppc64le -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=linux   GOARCH=riscv64 $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-riscv64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=darwin  GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-amd64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=darwin  GOARCH=arm64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-arm64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
-	env GOOS=windows GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-windows-amd64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+build: prep-build-dir
+	env GOOS=linux  GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
 .PHONY: build
+
+cross-build-darwin-amd64:
+	env GOOS=darwin  GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-amd64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-darwin-amd64
+
+cross-build-darwin-arm64:
+	env GOOS=darwin  GOARCH=arm64	$(GO) build -o $(GO_BUILD_BINDIR)/client-darwin-arm64  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-darwin-arm64
+
+cross-build-windows-amd64:
+	env GOOS=windows GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-windows-amd64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-windows-amd64
+
+cross-build-linux-amd64:
+	env GOOS=linux   GOARCH=amd64	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-amd64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-linux-amd64
+
+cross-build-linux-arm64:
+	env GOOS=linux   GOARCH=arm64   $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-arm64   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-linux-arm64
+
+cross-build-linux-ppc64le:
+	env GOOS=linux   GOARCH=ppc64le $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-ppc64le -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-linux-ppc64le
+
+cross-build-linux-s390x:
+	env GOOS=linux   GOARCH=s390x	$(GO) build -o $(GO_BUILD_BINDIR)/client-linux-s390x   -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-linux-s390x
+
+cross-build-linux-riscv64:
+	env GOOS=linux   GOARCH=riscv64 $(GO) build -o $(GO_BUILD_BINDIR)/client-linux-riscv64 -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)
+.PHONY: cross-build-linux-riscv64
+
+cross-build: prep-build-dir cross-build-darwin-amd64 cross-build-darwin-arm64 cross-build-windows-amd64 cross-build-linux-amd64 cross-build-linux-arm64 cross-build-linux-ppc64le cross-build-linux-s390x cross-build-linux-riscv64
+.PHONY: cross-build
+
+prep-build-dir:
+	mkdir -p ${GO_BUILD_BINDIR}
+.PHONY: prep-build-dir
 
 vendor:
 	$(GO) mod tidy
@@ -50,3 +81,6 @@ vet:
 
 all: clean vendor test-unit build
 .PHONY: all
+
+cross-build-all: clean vendor test-unit cross-build
+.PHONY: cross-build-all


### PR DESCRIPTION
…oss-build target

Changes the default target to a default of Linux amd64 and a binary name of `client` for quick development.
Add a cross-build target to perform multi-arch builds deliberately.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>